### PR TITLE
rename labeler gh workflow to be more generic as a pull request workflow

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -1,0 +1,5 @@
+# Set to true to add reviewers to pull requests
+addReviewers: false
+
+# Set addAssignees to 'author' to set the PR creator as the assignee.
+addAssignees: author

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: 'Pull Request Labeler'
+name: 'Pull Request'
 
 on:
   pull_request_target:
@@ -11,7 +11,9 @@ on:
       - '*.md'
       - 'apps/**/*.md'
       - 'packages/**/*.md'
+    types: [opened, ready_for_review]
 
+# Security Note: intentionally using actions that do not require a git checkout
 jobs:
   label:
     permissions:
@@ -22,3 +24,8 @@ jobs:
       - uses: actions/labeler@v4
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
+  # Action works against `.github/auto-assign.yml`
+  add-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.1


### PR DESCRIPTION
add auto-assign github action